### PR TITLE
Remove year from footer in copyright of all pages

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -22,7 +22,7 @@ export const Footer = () => {
             <div>Switzerland</div>
           </div>
           <div className={styles.footerText}>
-            ©2021 HOPR Association, all rights reserved
+            © HOPR Association, all rights reserved
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes: https://www.notion.so/hoprnet/remove-2022-from-footer-in-copyright-of-all-pages-9e1cc6dacd4543059a72079f9a97e819
### Tasks:
- [x] Remove year 2021 from footer
### Evidence:
![image](https://user-images.githubusercontent.com/59750365/214307887-7fc02863-30aa-4862-9d27-15d328f50c61.png)
