### PR TITLE
Add category field to Bounty object & fix image path

### DIFF
--- a/shared/sheet.ts
+++ b/shared/sheet.ts
@@ -31,7 +31,8 @@ const COLUMNS = <const>{
   title: "title",
   description: "description",
   prize: "prize (USD)",
-  contest: "contest"
+  contest: "contest",
+  category: 'category'
 };
 
 const FilterByType =
@@ -73,6 +74,7 @@ const toHomePageBounty = (row: GoogleSpreadsheetRow): Partial<Bounty> => {
       return undefined;
     }
   })();
+  const category = row[COLUMNS.category] ? row[COLUMNS.category] : null;
 
   return {
     status,
@@ -83,6 +85,7 @@ const toHomePageBounty = (row: GoogleSpreadsheetRow): Partial<Bounty> => {
     description: row[COLUMNS.description],
     contest,
     submittedOn,
+    category
   };
 };
 

--- a/src/components/bounty-cell.tsx
+++ b/src/components/bounty-cell.tsx
@@ -14,7 +14,7 @@ export const BountyCell: React.FC<{
           <div className={styles.imgContainer}>
             <Image
               className={styles.img}
-              src={bounty.category ? `/images/bounties${bounty.category.toLowerCase()}.svg` : '/images/bounties/development.svg'}
+              src={bounty.category ? `/images/bounties/${bounty.category.toLowerCase()}.svg` : '/images/bounties/development.svg'}
               alt="App dev"
               height={160}
               width={300}


### PR DESCRIPTION
### Description:
Add category field to the bounties objects so now we have different cover images based on the category defined at the spreadsheet. Also fixed the image path, it was missing a `/`.

### Evidence:
![image](https://github.com/szczebel1995/Hopr-Bounty-page/assets/59750365/128798c5-74b5-497a-a4a8-2560b0b2222b)
